### PR TITLE
[Bug]Fix the Fake-source error to define binary data

### DIFF
--- a/bitsail-connectors/connector-fake/src/main/java/com/bytedance/bitsail/connector/fake/source/FakeSourceReader.java
+++ b/bitsail-connectors/connector-fake/src/main/java/com/bytedance/bitsail/connector/fake/source/FakeSourceReader.java
@@ -92,7 +92,7 @@ public class FakeSourceReader extends SimpleSourceReaderBase<Row> {
     } else if (PrimitiveTypes.DOUBLE.getTypeInfo().getTypeClass() == typeInfo.getTypeClass()) {
       return faker.number().randomDouble(5, -1_000_000_000, 1_000_000_000);
 
-    } else if (PrimitiveTypes.BYTE.getTypeInfo().getTypeClass() == typeInfo.getTypeClass()) {
+    } else if (PrimitiveTypes.BINARY.getTypeInfo().getTypeClass() == typeInfo.getTypeClass()) {
       return faker.name().fullName().getBytes();
 
     } else if (PrimitiveTypes.DATE_DATE.getTypeInfo().getTypeClass() == typeInfo.getTypeClass()) {

--- a/bitsail-connectors/connector-fake/src/test/resources/bitsail_connector_unified_conf.json
+++ b/bitsail-connectors/connector-fake/src/test/resources/bitsail_connector_unified_conf.json
@@ -19,8 +19,12 @@
           "type": "long"
         },
         {
-          "name": "id",
+          "name": "c_date",
           "type": "date"
+        },
+        {
+          "name": "c_binary",
+          "type": "binary"
         }
       ]
     },


### PR DESCRIPTION
Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
when I review the type convert module and plan to add fake-doc, Enhance some features of Fake to learn bitmail,
I found the binary data converted error.
byte is the number which between -128 to127.
String.getByte() is bytes，byte_arr or binary.

and BTW，is the type conversion task level?
The timeTimstamp is convert to Bigint, the Fake-Source con't distinguish the timestamp type.


Some description about what this PR wants to do.

## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

Some description about how this PR achives the purpose. 

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->

_e.g._ Close #796

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
