### PR TITLE
Remove setFetchSize in getStatement.

### DIFF
--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JDBCInputFormat.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JDBCInputFormat.java
@@ -624,8 +624,9 @@ public class JDBCInputFormat extends InputFormatPlugin<Row, InputSplit> implemen
    * For more details: <a href="https://mariadb.com/kb/en/about-mariadb-connector-j/#streaming-result-sets">MariaDB connector: streaming result sets</a>
    */
   public int getReaderFetchSize(int fetchSize) {
-    if (MysqlUtil.DRIVER_NAME.equalsIgnoreCase(getDriverName())) {
-      return 1;
+    if (fetchSize < 0) {
+      fetchSize = 1;
+      LOG.warn("fetch size should not be negative in jdbc reader.");
     }
     return fetchSize;
   }

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JDBCInputFormat.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JDBCInputFormat.java
@@ -618,9 +618,14 @@ public class JDBCInputFormat extends InputFormatPlugin<Row, InputSplit> implemen
     return new JDBCSourceEngineConnectorBase(commonConf, readerConf);
   }
 
+  /**
+   * In mariadb mysql java client, it enables streaming result set by `setFetchSize({any positive integer})`.<br/>
+   * In official mysql jdbc client, it enables streaming result set by `setFetchSize(INT.MIN_VALUE)`, and fetch one row once.<br/>
+   * For more details: <a href="https://mariadb.com/kb/en/about-mariadb-connector-j/#streaming-result-sets">MariaDB connector: streaming result sets</a>
+   */
   public int getReaderFetchSize(int fetchSize) {
     if (MysqlUtil.DRIVER_NAME.equalsIgnoreCase(getDriverName())) {
-      return Integer.MIN_VALUE;
+      return 1;
     }
     return fetchSize;
   }

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/split/DbShardWithConn.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/split/DbShardWithConn.java
@@ -195,8 +195,9 @@ public class DbShardWithConn {
         statement.close();
       }
 
+      // enable streaming result set by set fetch size to a positive value.
       if (statementReadOnly) {
-        statement = getConnection().prepareStatement(sqlTemplate, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        statement.setFetchSize(1);
       } else {
         statement = getConnection().prepareStatement(sqlTemplate);
       }

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/split/DbShardWithConn.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/split/DbShardWithConn.java
@@ -197,9 +197,6 @@ public class DbShardWithConn {
 
       if (statementReadOnly) {
         statement = getConnection().prepareStatement(sqlTemplate, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-        if (driverClassName.equalsIgnoreCase(MysqlUtil.DRIVER_NAME)) {
-          statement.setFetchSize(Integer.MIN_VALUE);
-        }
       } else {
         statement = getConnection().prepareStatement(sqlTemplate);
       }

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/split/DbShardWithConn.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/main/java/com/bytedance/bitsail/connector/legacy/jdbc/split/DbShardWithConn.java
@@ -195,11 +195,11 @@ public class DbShardWithConn {
         statement.close();
       }
 
+      statement = getConnection().prepareStatement(sqlTemplate);
+
       // enable streaming result set by set fetch size to a positive value.
       if (statementReadOnly) {
         statement.setFetchSize(1);
-      } else {
-        statement = getConnection().prepareStatement(sqlTemplate);
       }
 
       if (statementFetchSize > 0) {

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/container/MySQLContainerMariadbAdapter.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/container/MySQLContainerMariadbAdapter.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package com.bytedance.bitsail.connector.legacy.jdbc.sink.container;
+package com.bytedance.bitsail.connector.legacy.jdbc.container;
 
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -38,3 +38,4 @@ public class MySQLContainerMariadbAdapter<SELF extends MySQLContainerMariadbAdap
     return super.getJdbcUrl();
   }
 }
+

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/sink/JdbcSinkITCase.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/sink/JdbcSinkITCase.java
@@ -18,8 +18,8 @@
 package com.bytedance.bitsail.connector.legacy.jdbc.sink;
 
 import com.bytedance.bitsail.common.configuration.BitSailConfiguration;
+import com.bytedance.bitsail.connector.legacy.jdbc.container.MySQLContainerMariadbAdapter;
 import com.bytedance.bitsail.connector.legacy.jdbc.options.JdbcWriterOptions;
-import com.bytedance.bitsail.connector.legacy.jdbc.sink.container.MySQLContainerMariadbAdapter;
 import com.bytedance.bitsail.test.connector.test.EmbeddedFlinkCluster;
 import com.bytedance.bitsail.test.connector.test.utils.JobConfUtils;
 

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JdbcSourceITCase.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JdbcSourceITCase.java
@@ -22,12 +22,10 @@ import com.bytedance.bitsail.connector.legacy.jdbc.container.MySQLContainerMaria
 import com.bytedance.bitsail.connector.legacy.jdbc.model.ClusterInfo;
 import com.bytedance.bitsail.connector.legacy.jdbc.model.ConnectionInfo;
 import com.bytedance.bitsail.connector.legacy.jdbc.options.JdbcReaderOptions;
-import com.bytedance.bitsail.connector.legacy.jdbc.options.JdbcWriterOptions;
 import com.bytedance.bitsail.test.connector.test.EmbeddedFlinkCluster;
 import com.bytedance.bitsail.test.connector.test.utils.JobConfUtils;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +36,6 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 public class JdbcSourceITCase {

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JdbcSourceITCase.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JdbcSourceITCase.java
@@ -1,20 +1,18 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.bytedance.bitsail.connector.legacy.jdbc.source;

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JdbcSourceITCase.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/java/com/bytedance/bitsail/connector/legacy/jdbc/source/JdbcSourceITCase.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.bytedance.bitsail.connector.legacy.jdbc.source;
+
+import com.bytedance.bitsail.common.configuration.BitSailConfiguration;
+import com.bytedance.bitsail.connector.legacy.jdbc.container.MySQLContainerMariadbAdapter;
+import com.bytedance.bitsail.connector.legacy.jdbc.model.ClusterInfo;
+import com.bytedance.bitsail.connector.legacy.jdbc.model.ConnectionInfo;
+import com.bytedance.bitsail.connector.legacy.jdbc.options.JdbcReaderOptions;
+import com.bytedance.bitsail.connector.legacy.jdbc.options.JdbcWriterOptions;
+import com.bytedance.bitsail.test.connector.test.EmbeddedFlinkCluster;
+import com.bytedance.bitsail.test.connector.test.utils.JobConfUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class JdbcSourceITCase {
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceITCase.class);
+
+  private static final String MYSQL_DOCKER_IMAGER = "mysql:8.0.29";
+
+  private MySQLContainer<?> container;
+
+  @Before
+  public void before() {
+    container = new MySQLContainerMariadbAdapter<>(DockerImageName.parse(MYSQL_DOCKER_IMAGER))
+        .withUrlParam("permitMysqlScheme", null)
+        .withInitScript("scripts/jdbc_to_print.sql")
+        .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    Startables.deepStart(Stream.of(container)).join();
+  }
+
+  @After
+  public void after() {
+    container.close();
+  }
+
+  @Test
+  public void testMysqlReader() throws Exception {
+    BitSailConfiguration jobConf = JobConfUtils.fromClasspath("scripts/jdbc_to_print.json");
+
+    ConnectionInfo connectionInfo = ConnectionInfo.builder()
+        .host(container.getHost())
+        .port(container.getFirstMappedPort())
+        .url(container.getJdbcUrl())
+        .build();
+    ClusterInfo clusterInfo = ClusterInfo.builder()
+        .slave(connectionInfo)
+        .build();
+    jobConf.set(JdbcReaderOptions.CONNECTIONS, Lists.newArrayList(clusterInfo));
+
+    EmbeddedFlinkCluster.submitJob(jobConf);
+  }
+}

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/resources/scripts/jdbc_to_print.json
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/resources/scripts/jdbc_to_print.json
@@ -1,0 +1,51 @@
+{
+  "job": {
+    "common": {
+      "cid": 0,
+      "domain": "test",
+      "job_id": -23,
+      "job_name": "bitsail_test_mysql_source",
+      "instance_id": -203,
+      "user_name": "test"
+    },
+    "reader": {
+      "class": "com.bytedance.bitsail.connector.legacy.jdbc.source.JDBCInputFormat",
+      "db_name": "test",
+      "table_name": "jdbc_source_test",
+      "split_pk": "id",
+      "connections": [
+      ],
+      "user_name": "test",
+      "password": "test",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint unsigned"
+        },
+        {
+          "name": "int_type",
+          "type": "int"
+        },
+        {
+          "name": "double_type",
+          "type": "decimal"
+        },
+        {
+          "name": "date_type",
+          "type": "varchar"
+        },
+        {
+          "name": "varchar_type",
+          "type": "varchar"
+        },
+        {
+          "name": "datetime",
+          "type": "date"
+        }
+      ]
+    },
+    "writer": {
+      "class": "com.bytedance.bitsail.connector.legacy.print.sink.PrintSink"
+    }
+  }
+}

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/resources/scripts/jdbc_to_print.sql
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/resources/scripts/jdbc_to_print.sql
@@ -1,21 +1,20 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *    http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 
 use test;
 

--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/resources/scripts/jdbc_to_print.sql
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-jdbc/src/test/resources/scripts/jdbc_to_print.sql
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+use test;
+
+create TABLE `jdbc_source_test`
+(
+    `id`             bigint unsigned NOT NULL AUTO_INCREMENT,
+    `int_type`       int                                      NOT NULL DEFAULT '0',
+    `double_type`    decimal(20, 4)                                    DEFAULT NULL,
+    `date_type`      varchar(128) COLLATE utf8mb4_general_ci           DEFAULT NULL,
+    `varchar_type`   varchar(1024) COLLATE utf8mb4_general_ci          DEFAULT '',
+    `datetime`       date                                     NOT NULL COMMENT 'date',
+    PRIMARY KEY (`id`, `datetime`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+insert into `jdbc_source_test` (`int_type`, `double_type`, `date_type`, `varchar_type`, `datetime`)
+VALUES
+(1001, 11.11, '2022-10-01', 'varchar_01', '2022-11-01'),
+(1002, 22.22, '2022-10-02', 'varchar_02', '2022-11-02'),
+(1003, 33.33, '2022-10-03', 'varchar_03', '2022-11-03'),
+(1004, 44.44, '2022-10-04', 'varchar_04', '2022-11-04'),
+(1005, 55.55, '2022-10-05', 'varchar_05', '2022-11-05'),
+(1006, 66.66, '2022-10-06', 'varchar_06', '2022-11-06'),
+(1007, 77.77, '2022-10-07', 'varchar_07', '2022-11-07'),
+(1008, 88.88, '2022-10-08', 'varchar_08', '2022-11-08'),
+(1009, 99.99, '2022-10-09', 'varchar_09', '2022-11-09'),
+(1010, 10.10, '2022-10-10', 'varchar_10', '2022-11-10');


### PR DESCRIPTION
BugFix: setFetchSize only supports non-negative number.

Signed-off-by: Liu Peng <96pengpeng@gmail.com>

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

In `DbShardWithConn`, it sets fetch size to a negative number.
<img width="1107" alt="截屏2022-11-02 15 21 59" src="https://user-images.githubusercontent.com/22468412/199425165-ba5bd0e2-a832-4fe0-976b-8955687826e5.png">

But in `mariadb-java-client` driver, the fetch size cannot be negative.
<img width="1075" alt="截屏2022-11-02 15 22 39" src="https://user-images.githubusercontent.com/22468412/199425281-ac44a927-5ee6-4042-a14a-877eda1de4bb.png">



## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

As mentioned in this doc [MariaDB connector: streaming result sets](https://mariadb.com/kb/en/about-mariadb-connector-j/#streaming-result-sets), MariaDB supports streaming result sets by set fetch size to a positive number.

So we just need to set a positive fetch size.

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->

_e.g._ Close #84 

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
