### PR TITLE
[BitSail][core]fixed row utils high cpu usage issue.

### DIFF
--- a/bitsail-cores/bitsail-core-flink/src/main/java/com/bytedance/bitsail/flink/core/util/RowUtil.java
+++ b/bitsail-cores/bitsail-core-flink/src/main/java/com/bytedance/bitsail/flink/core/util/RowUtil.java
@@ -19,9 +19,14 @@ package com.bytedance.bitsail.flink.core.util;
 
 import com.bytedance.bitsail.common.column.Column;
 
-import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator;
 import org.apache.flink.types.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.security.Timestamp;
+import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -30,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 public class RowUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(RowUtil.class);
 
   public static long getRowBytesSize(Row row) {
     long totalBytes = 0L;
@@ -113,7 +119,14 @@ public class RowUtil {
       return ((Byte[]) field).length;
     }
 
-    if (clazz.isAssignableFrom(Date.class)) {
+    if (clazz == BigDecimal.class
+        || clazz == BigInteger.class) {
+      return 16L;
+    }
+
+    if (clazz.isAssignableFrom(Date.class)
+        || clazz.isAssignableFrom(Timestamp.class)
+        || clazz.isAssignableFrom(Time.class)) {
       return 12L;
     }
 
@@ -127,6 +140,7 @@ public class RowUtil {
       return 15L;
     }
 
-    return ObjectSizeCalculator.getObjectSize(field);
+    LOG.debug("Object value = {} can't supported in current.", field);
+    return 0L;
   }
 }


### PR DESCRIPTION
Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
In history, we use `RowUtil` to calcalate object size for the reader and writer side. In most case we directly return the constants for the object, but when we we meet object like `bigdecimal` or `biginteger` or any object else, we will try use `ObjectSizeCalculator.getObjectSize` to calcualte object size.

`ObjectSizeCalculator.getObjectSize` is simple enought to let us get real object size, but it will consumer more CPU usage than we think. 

We compare the profile usage between the `ObjectSizeCalculator.getObjectSize` and `constants value`, it show there will have 50% extra CPU usgae in the `ObjectSizeCalculator.getObjectSize` case.
Some description about what this PR wants to do.

<img width="1133" alt="截屏2022-11-22 21 21 33" src="https://user-images.githubusercontent.com/14176134/203324451-55e93eab-1e5b-4e0f-8ac4-b68ab5db37f9.png">
<img width="936" alt="截屏2022-11-22 21 21 43" src="https://user-images.githubusercontent.com/14176134/203324468-a4f941a2-fe06-4fda-a68e-631b311a2b79.png">

## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

Some description about how this PR achives the purpose. 

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->

_e.g._ Close #796

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
