### PR TITLE
[BitSail][bugfix] RocketMQ splitId HashCode may be negative.

### DIFF
--- a/bitsail-connectors/connector-rocketmq/src/main/java/com/bytedance/bitsail/connector/rocketmq/source/coordinator/FairRocketMQSplitAssigner.java
+++ b/bitsail-connectors/connector-rocketmq/src/main/java/com/bytedance/bitsail/connector/rocketmq/source/coordinator/FairRocketMQSplitAssigner.java
@@ -54,6 +54,6 @@ public class FairRocketMQSplitAssigner implements SplitAssigner<MessageQueue> {
 
   @Override
   public int assignToReader(String splitId, int totalParallelism) {
-    return splitId.hashCode() % totalParallelism;
+    return (splitId.hashCode() & Integer.MAX_VALUE) % totalParallelism;
   }
 }


### PR DESCRIPTION
Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

HashCode may be negative，the result of the mod calculation is a negative number.

## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

Some description about how this PR achives the purpose. 

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->

_e.g._ Close #796

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
