### PR TITLE
[BitSail][Bug] Fixed csv deserialization failure when delimiter's len…

### DIFF
--- a/bitsail-components/bitsail-component-formats/bitsail-component-format-csv/src/main/java/com/bytedance/bitsail/component/format/csv/CsvDeserializationSchema.java
+++ b/bitsail-components/bitsail-component-formats/bitsail-component-format-csv/src/main/java/com/bytedance/bitsail/component/format/csv/CsvDeserializationSchema.java
@@ -96,7 +96,16 @@ public class CsvDeserializationSchema implements DeserializationSchema<byte[], R
   public Row deserialize(byte[] message) {
     CSVRecord csvRecord;
     try {
-      CSVParser parser = CSVParser.parse(new String(message), csvFormat);
+      String inputStr = new String(message);
+      String csvMultiDelimiterReplaceString = csvMultiDelimiterReplaceChar.toString();
+      if ((csvDelimiter.length() > 1) && inputStr.contains(csvMultiDelimiterReplaceString)) {
+        throw new BitSailException(CsvFormatErrorCode.CSV_FORMAT_SCHEMA_PARSE_FAILED,
+            String.format("Input row contains '%c', the csv_multi_delimiter_replace_char option should be set to other character e.g. '⊙'.",
+                csvMultiDelimiterReplaceChar));
+      } else if (csvDelimiter.length() > 1) {
+        inputStr = inputStr.replace(csvDelimiter, csvMultiDelimiterReplaceString);
+      }
+      CSVParser parser = CSVParser.parse(inputStr, csvFormat);
       csvRecord =  parser.getRecords().get(0);
     } catch (Exception e) {
       throw BitSailException.asBitSailException(CsvFormatErrorCode.CSV_FORMAT_SCHEMA_PARSE_FAILED, e);

--- a/bitsail-components/bitsail-component-formats/bitsail-component-format-csv/src/test/java/com/bytedance/bitsail/component/format/csv/CsvDeserializationSchemaTest.java
+++ b/bitsail-components/bitsail-component-formats/bitsail-component-format-csv/src/test/java/com/bytedance/bitsail/component/format/csv/CsvDeserializationSchemaTest.java
@@ -40,7 +40,7 @@ public class CsvDeserializationSchemaTest {
   }
 
   @Test
-  public void testCsvDeltmiter() {
+  public void testCsvDelimiter() {
     BitSailConfiguration jobConf = BitSailConfiguration.newDefault();
     jobConf.set(CsvReaderOptions.CSV_DELIMITER, "#");
     TypeInfo<?>[] typeInfos = {TypeInfos.STRING_TYPE_INFO, TypeInfos.INT_TYPE_INFO};
@@ -61,6 +61,19 @@ public class CsvDeserializationSchemaTest {
     TypeInfo<?>[] typeInfos = {TypeInfos.STRING_TYPE_INFO, TypeInfos.INT_TYPE_INFO};
     String[] fieldNames = {"c1", "c2"};
     String csv = "\"star\"#2222";
+    CsvDeserializationSchema deserializationSchema = new CsvDeserializationSchema(jobConf, typeInfos, fieldNames);
+    Row row = deserializationSchema.deserialize(csv.getBytes());
+    Assert.assertEquals(row.getField(0).toString(), "star");
+    Assert.assertEquals((int) row.getField(1), 2222);
+  }
+
+  @Test
+  public void testCsvMultiDelimiterReplaceChar() {
+    BitSailConfiguration jobConf = BitSailConfiguration.newDefault();
+    jobConf.set(CsvReaderOptions.CSV_DELIMITER, "##");
+    TypeInfo<?>[] typeInfos = {TypeInfos.STRING_TYPE_INFO, TypeInfos.INT_TYPE_INFO};
+    String[] fieldNames = {"c1", "c2"};
+    String csv = "star##2222";
     CsvDeserializationSchema deserializationSchema = new CsvDeserializationSchema(jobConf, typeInfos, fieldNames);
     Row row = deserializationSchema.deserialize(csv.getBytes());
     Assert.assertEquals(row.getField(0).toString(), "star");


### PR DESCRIPTION
…gth is more than 1

Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
1. To fix the bug of csv deserialization, it would throw error when delimiter's length is more than 1.
2. To correct wrong function name `testCsvDeltmiter()` as `testCsvDelimiter()`
3. To add a test case as function `testCsvMultiDelimiterReplaceChar()`


## Approaches
By adding string replacement procedure, it can pass the test function `testCsvMultiDelimiterReplaceChar()`.

Some description about how this PR achives the purpose. 

## Related Issues
Close #307

## New Behavior (screenshots if needed)
N/A
