### PR TITLE
[BitSail][Defect] output formats not closed in `PartitionWriter.close()`

### DIFF
--- a/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-streamingfile/bitsail-connector-streamingfile-common/src/main/java/com/bytedance/bitsail/connector/legacy/streamingfile/common/filesystem/PartitionWriter.java
+++ b/bitsail-connectors/bitsail-connectors-legacy/bitsail-connector-streamingfile/bitsail-connector-streamingfile-common/src/main/java/com/bytedance/bitsail/connector/legacy/streamingfile/common/filesystem/PartitionWriter.java
@@ -200,6 +200,9 @@ public abstract class PartitionWriter<T> {
     if (clearPartFileInfo) {
       clearPartFileInfo();
     }
+    for (String partition: getOutputFormats().keySet()) {
+      closeFormatForPartition(partition);
+    }
   }
 
   public void clearPartFileInfo() {


### PR DESCRIPTION
unclosed resources may cause resource leaks.

Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

try to close output formats when the `PartitionWriter.close()` method is called, to release the opened resources.

## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

call `closeFormatForPartition(String)` in `PartitionWriter.close()`

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->


## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
