### PR TITLE
[BitSail][Features] Support list and map in current FileMappingTypeInfoConverter

### DIFF
--- a/bitsail-common/src/main/java/com/bytedance/bitsail/common/type/BitSailTypeParser.java
+++ b/bitsail-common/src/main/java/com/bytedance/bitsail/common/type/BitSailTypeParser.java
@@ -41,7 +41,25 @@ public class BitSailTypeParser {
   private static final String SPLIT_TOKEN = ",";
 
   public static String fromTypeInfo(TypeInfo<?> typeInfo) {
-    return TypeInfoBridge.bridgeTypes(typeInfo);
+    Preconditions.checkNotNull(typeInfo, "typeInfo can not be null.");
+
+    if (typeInfo instanceof ListTypeInfo || typeInfo instanceof MapTypeInfo) {
+
+      if (typeInfo instanceof MapTypeInfo) {
+        MapTypeInfo mapTypeInfo = (MapTypeInfo) typeInfo;
+        return String.format("%s<%s, %s>", Types.MAP.name(), fromTypeInfo(mapTypeInfo.getKeyTypeInfo()), fromTypeInfo(mapTypeInfo.getValueTypeInfo()));
+      } else {
+
+        ListTypeInfo listTypeInfo = (ListTypeInfo) typeInfo;
+        return String.format("%s<%s>", Types.LIST.name(), fromTypeInfo(listTypeInfo.getElementTypeInfo()));
+      }
+    }
+    String typeString = TypeInfoBridge.bridgeTypes(typeInfo);
+    if (StringUtils.isEmpty(typeString)) {
+      throw BitSailException.asBitSailException(CommonErrorCode.INTERNAL_ERROR,
+        String.format("Not support type typeInfo %s.", typeInfo));
+    }
+    return typeString;
   }
 
   public static List<TypeProperty> fromTypePropertyString(String typePropertyString) {

--- a/bitsail-common/src/test/java/com/bytedance/bitsail/common/type/SimpleTypeInfoConverterTest.java
+++ b/bitsail-common/src/test/java/com/bytedance/bitsail/common/type/SimpleTypeInfoConverterTest.java
@@ -21,8 +21,10 @@ import com.bytedance.bitsail.common.type.filemapping.FileMappingTypeInfoReader;
 import com.bytedance.bitsail.common.typeinfo.TypeInfo;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,15 +32,56 @@ import java.util.Map;
  */
 public class SimpleTypeInfoConverterTest {
 
-  @Test
-  public void testSimpleTypeInfoConverter() {
-    FileMappingTypeInfoConverter fileMappingTypeInfoConverter = new FileMappingTypeInfoConverter("fake");
-    FileMappingTypeInfoReader reader = fileMappingTypeInfoConverter.getReader();
-    Map<String, TypeInfo<?>> toTypeInformation = reader.getToTypeInformation();
-    Map<TypeInfo<?>, String> fromTypeInformation = reader.getFromTypeInformation();
+  private FileMappingTypeInfoConverter fileMappingTypeInfoConverter;
+  private Map<String, TypeInfo<?>> toTypeInformation;
+  private Map<TypeInfo<?>, String> fromTypeInformation;
 
-    Assert.assertEquals(toTypeInformation.size(), 8);
-    Assert.assertEquals(fromTypeInformation.size(), 6);
+  @Before
+  public void before() {
+    fileMappingTypeInfoConverter = new FileMappingTypeInfoConverter("fake");
+    FileMappingTypeInfoReader reader = fileMappingTypeInfoConverter.getReader();
+    toTypeInformation = reader.getToTypeInformation();
+    fromTypeInformation = reader.getFromTypeInformation();
   }
 
+  @Test
+  public void testSimpleTypeInfoConverter() {
+    Assert.assertEquals(toTypeInformation.size(), 8);
+    Assert.assertEquals(fromTypeInformation.size(), 7);
+  }
+
+  @Test
+  public void testFromTypeString_ListType() {
+    TypeInfo<?> typeInfo01 = fileMappingTypeInfoConverter.fromTypeString("Array(double)");
+    Assert.assertEquals(typeInfo01.getTypeClass(), List.class);
+
+    TypeInfo<?> typeInfo02 = fileMappingTypeInfoConverter.fromTypeString("Array(Array(double))");
+    Assert.assertEquals(typeInfo02.getTypeClass(), List.class);
+  }
+
+  @Test
+  public void testFromTypeString_MapType() {
+    TypeInfo<?> typeInfo01 = fileMappingTypeInfoConverter.fromTypeString("Map(string,double)");
+    Assert.assertEquals(typeInfo01.getTypeClass(), Map.class);
+
+    TypeInfo<?> typeInfo02 = fileMappingTypeInfoConverter.fromTypeString("Map(string, Map(string, double))");
+    Assert.assertEquals(typeInfo02.getTypeClass(), Map.class);
+  }
+
+  @Test
+  public void testFromTypeInfo_ListType() {
+    TypeInfo<?> typeInfo = fileMappingTypeInfoConverter.fromTypeString("Array(Array(Int32))");
+    Assert.assertEquals(typeInfo.getTypeClass(), List.class);
+
+    String typeString = fileMappingTypeInfoConverter.fromTypeInfo(typeInfo);
+    Assert.assertEquals(typeString, "Array(Array(Int32))");
+  }
+
+  @Test
+  public void testFromTypeInfo_MapType() {
+    TypeInfo<?> typeInfo = fileMappingTypeInfoConverter.fromTypeString("Map(string, Map(string, double))");
+
+    String typeString = fileMappingTypeInfoConverter.fromTypeInfo(typeInfo);
+    Assert.assertEquals(typeString, "Map(string, Map(string, double))");
+  }
 }

--- a/bitsail-common/src/test/resources/fake-type-converter.yaml
+++ b/bitsail-common/src/test/resources/fake-type-converter.yaml
@@ -17,8 +17,8 @@ engine.type.to.bitsail.type.converter:
   - source.type: double
     target.type: double
 
-  - source.type: int
-    target.type: long
+  - source.type: Int32
+    target.type: int
 
   - source.type: bigint
     target.type: long
@@ -26,7 +26,7 @@ engine.type.to.bitsail.type.converter:
 
 bitsail.type.to.engine.type.converter:
   - source.type: long
-    target.type: long
+    target.type: bigint
 
   - source.type: double
     target.type: double
@@ -42,3 +42,34 @@ bitsail.type.to.engine.type.converter:
 
   - source.type: bytes
     target.type: bytes
+
+  - source.type: int
+    target.type: Int32
+
+
+engine.type.to.bitsail.complex.converter:
+  - source.type: Array
+    target.type: list
+
+  - source.type: Map
+    target.type: map
+
+  - source.type: (
+    target.type: <
+
+  - source.type: )
+    target.type: '>'
+
+bitsail.type.to.engine.complex.converter:
+  - source.type: list
+    target.type: Array
+
+  - source.type: map
+    target.type: Map
+
+  - source.type: <
+    target.type: (
+
+  - source.type: '>'
+    target.type: )
+


### PR DESCRIPTION
Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
- close #251 

## Approaches
For complex types like list and Map, use _BitSail type string_ as the bridge between _engine type string_ and _typeInfo_, and convert _engine type string_ like Map(String,Map(String,Int32)) into map<string,map<string ,int>> such _BitSail type string_, and then realize the conversion between _BitSail type string_ and _typeInfo_ through BitSailTypeParser
<img width="563" alt="image" src="https://user-images.githubusercontent.com/39974301/215936843-85ec8f42-36b6-46fb-adb9-1ecda95ed5d4.png">



## Related Issues
- close #251 

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
