### PR TITLE
[BitSail][Base] Support get build version from package info.

### DIFF
--- a/bitsail-base/pom.xml
+++ b/bitsail-base/pom.xml
@@ -162,6 +162,28 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>de.shadowhunt.maven.plugins</groupId>
+                <artifactId>package-info-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>package-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packages>
+                        <package regex="com.bytedance.bitsail.base.version">
+                            <annotations>
+                                <annotation>@com.bytedance.bitsail.base.version.VersionInfoAnnotation(version = "${revision}")</annotation>
+                            </annotations>
+                        </package>
+                    </packages>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/bitsail-base/src/main/java/com/bytedance/bitsail/base/version/VersionHolder.java
+++ b/bitsail-base/src/main/java/com/bytedance/bitsail/base/version/VersionHolder.java
@@ -16,6 +16,7 @@
 
 package com.bytedance.bitsail.base.version;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,19 @@ public class VersionHolder {
       }
     } catch (Exception e) {
       LOG.info("Cannot determine code revision: Unable to read version property file.", e);
+    }
+
+    // Obtain git version from package info
+    if (!isBuildVersionValid(gitBuildVersion)) {
+      try {
+        Package curPkg = VersionHolder.class.getPackage();
+        VersionInfoAnnotation annotation = curPkg.getAnnotation(VersionInfoAnnotation.class);
+        if (StringUtils.isNotEmpty(annotation.version())) {
+          gitBuildVersion = annotation.version();
+        }
+      } catch (Exception ignored) {
+        gitBuildVersion = UNKNOWN;
+      }
     }
   }
 

--- a/bitsail-base/src/main/java/com/bytedance/bitsail/base/version/VersionInfoAnnotation.java
+++ b/bitsail-base/src/main/java/com/bytedance/bitsail/base/version/VersionInfoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Bytedance Ltd. and/or its affiliates.
+ * Copyright 2022-2023 Bytedance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bitsail-base/src/main/java/com/bytedance/bitsail/base/version/VersionInfoAnnotation.java
+++ b/bitsail-base/src/main/java/com/bytedance/bitsail/base/version/VersionInfoAnnotation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Bytedance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytedance.bitsail.base.version;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE})
+public @interface VersionInfoAnnotation {
+
+  String version() default "";
+}

--- a/bitsail-base/src/test/java/com/bytedance/bitsail/base/version/PackageInfoTest.java
+++ b/bitsail-base/src/test/java/com/bytedance/bitsail/base/version/PackageInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Bytedance Ltd. and/or its affiliates.
+ * Copyright 2022-2023 Bytedance Ltd. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bitsail-base/src/test/java/com/bytedance/bitsail/base/version/PackageInfoTest.java
+++ b/bitsail-base/src/test/java/com/bytedance/bitsail/base/version/PackageInfoTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Bytedance Ltd. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytedance.bitsail.base.version;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PackageInfoTest {
+  @Test
+  public void test() {
+    Package myPackage = VersionInfoAnnotation.class.getPackage();
+    VersionInfoAnnotation annotation = myPackage.getAnnotation(VersionInfoAnnotation.class);
+    Assert.assertTrue(StringUtils.isNotEmpty(annotation.version()));
+  }
+}


### PR DESCRIPTION
Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

PluginManager needs build version to recognize and find the target connector libs.

We use VersionHolder to generate build version, which depends on that the project is initialized with `git`.

However, users may directly download zip files instead  of git clone, there will be no git information under the unzipped project, which leads to failure as issue #177 says.
  


## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

We use [package-info-maven-plugin](https://github.com/thrawn-sh/package-info) to generate a `package-info.java` file under src dir.
The `package-info.java` file contains the project version info, so we can get project build version from the package annotation.

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->

#177 

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
