### PR TITLE
[BitSail][bug] Fix PrintSink does not support output NULL values.

### DIFF
--- a/bitsail-connectors/connector-print/src/main/java/com/bytedance/bitsail/connector/print/sink/PrintWriter.java
+++ b/bitsail-connectors/connector-print/src/main/java/com/bytedance/bitsail/connector/print/sink/PrintWriter.java
@@ -81,7 +81,8 @@ public class PrintWriter implements Writer<Row, String, Integer> {
   private String stringByRow(Row element) {
     String[] fields = new String[element.getFields().length];
     for (int i = 0; i < element.getFields().length; ++i) {
-      fields[i] = String.format("\"%s\":\"%s\"", fieldNames[i], element.getField(i).toString());
+      fields[i] = String.format("\"%s\":\"%s\"", fieldNames[i],
+          element.getField(i) == null ? null : element.getField(i).toString());
     }
     return String.format("[%s]", String.join(",", fields));
   }


### PR DESCRIPTION
Signed-off-by:

## Pre-Checklist

Note: Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/bytedance/bitsail/blob/master/docs/contributing.md) documentation.
- [x] My code has the necessary comments and documentation (if needed).
- [x] I have added relevant tests.

## Purpose
<!--
Describe what this PR does and what problems it tries to solve in a few sentences.
-->

Current PrintSink will throw NPE when output null values.
```java
fields[i] = String.format("\"%s\":\"%s\"", fieldNames[i], element.getField(i).toString());
```

## Approaches
<!--
Describe how this PR achieve the mentioned purpose in a few senteces.
-->

Check if the value is null before convert it to string.

## Related Issues
<!--
Will this PR close any open issue? If yes, would you please mention the issue(s) here?
-->

N/A

## New Behavior (screenshots if needed)
<!-- 
Describe the newly updated behavior, if relevant.
-->

N/A
