### PR TITLE
[BitSail][Common]Add java opts env for bitsail shell

### DIFF
--- a/bitsail-dist/src/main/resources/bin/bitsail
+++ b/bitsail-dist/src/main/resources/bin/bitsail
@@ -35,6 +35,11 @@ BITSAIL_CLIENT_CLASSPATH=${BITSAIL_HOME}/libs/clients
 if [ -n "$HADOOP_HOME" ]; then
   export HADOOP_CLASSPATH=$($HADOOP_HOME/bin/hadoop classpath)
 fi
+
+if [ -z "$BITSAIL_JAVA_OPTS" ]; then
+  export BITSAIL_JAVA_OPTS="-Xmx128M"
+fi
+
 export BITSAIL_HOME=${BITSAIL_HOME}
 
-exec java -cp ${BITSAIL_CLIENT_CLASSPATH}/*:${HADOOP_CLASSPATH}:${BITSAIL_CONF_DIR}/* com.bytedance.bitsail.client.entry.Entry ${args}
+exec java ${BITSAIL_JAVA_OPTS} -cp ${BITSAIL_CLIENT_CLASSPATH}/*:${HADOOP_CLASSPATH}:${BITSAIL_CONF_DIR}/* com.bytedance.bitsail.client.entry.Entry ${args}


### PR DESCRIPTION
When we submit a task using Bitsail, Bitsail initiates two processes: "Entry" and "CliFrontend." If we don't specify Java program parameters, they default to setting the Java heap memory (Xmx) to 1/4 of the maximum server memory when they start. This behavior is not container-friendly when using the Bitsail client, as it may lead to container Out of Memory (OOM) issues. We should have some limitations in place.

Flink provides the `FLINK_ENV_JAVA_OPTS_CLI` environment variable to set the memory usage for CliFrontend. However, Bitsail does not offer a similar configuration. This pull request introduces the `BITSAIL_JAVA_OPTS` configuration to restrict the memory and other related resources used by Bitsail processes.